### PR TITLE
Fix generated messages

### DIFF
--- a/src/js/validator.js
+++ b/src/js/validator.js
@@ -82,7 +82,7 @@ class Validator
 			if (this[methods[method]] && ! this[methods[method]](value)) {
 				this.stackErrors({
 					key: field, //evaluated field.
-					error: this.messages[methods[method]]
+					error: this.messages[field]
 				});
 			}
 		}


### PR DESCRIPTION
Generated errors messages were generated by looking up failed 'validation method' in the messages dictionary, but as from the documentation, messages keys should be based on rule names, not validation methods.